### PR TITLE
Discard return value of write() in oom_handler

### DIFF
--- a/src/node/main.c
+++ b/src/node/main.c
@@ -46,7 +46,7 @@ static void oom_handler() {
 	static const char* OOM_MSG = "Out of memory\n";
 
 	/* write w/o return check. we are torched anyway */
-	write(STDOUT_FILENO, OOM_MSG, sizeof(OOM_MSG)-1);
+	(void) write(STDOUT_FILENO, OOM_MSG, sizeof(OOM_MSG)-1);
 	abort();
 }
 


### PR DESCRIPTION
Discard the return value of the write() call in oom_handler. 
This allows to compile with -Werror and -Wunused-value as used in Debian.
