### PR TITLE
Add fake return value check for write() to work around -Wunused-result

### DIFF
--- a/src/node/main.c
+++ b/src/node/main.c
@@ -45,8 +45,8 @@ static int handle_connection();
 static void oom_handler() {
 	static const char* OOM_MSG = "Out of memory\n";
 
-	/* write w/o return check. we are torched anyway */
-	(void) write(STDOUT_FILENO, OOM_MSG, sizeof(OOM_MSG)-1);
+	/* write with fake return check. we are torched anyway */
+	if(write(STDOUT_FILENO, OOM_MSG, sizeof(OOM_MSG)-1)) {};
 	abort();
 }
 


### PR DESCRIPTION
- This allows to compile with -Werror and -Wunused-result as used in Debian.
