### PR TITLE
node: Don't ignore return value of setgid / setuid

### DIFF
--- a/src/node/node.c
+++ b/src/node/node.c
@@ -464,15 +464,16 @@ static void setenvvars_conf(char* current_plugin_name) {
 	/* setuid/gid */
 	if (geteuid() == 0) {
 		/* We *are* root */
-		(void)setgid(pconf.gid);
-		if(getgid() != pconf.gid) {
-			perror("gid not changed by setgid");
-			abort();
+		int ret_val;
+		ret_val = setgid(pconf.gid);
+		if ((ret_val =! 0) || (getgid() != pconf.gid)) {
+				perror("gid not changed by setgid");
+				abort();
 		}
 
 		/* Change UID *after* GID, otherwise cannot change anymore */
-		(void)setuid(pconf.uid);
-		if(getuid() != pconf.uid) {
+		ret_val = setuid(pconf.uid);
+		if ((ret_val != 0) || (getuid() != pconf.uid)) {
 			perror("uid not changed by setuid");
 			abort();
 		}


### PR DESCRIPTION
With activated hardening flags -Werror=unused-result breaks the build if return values are ignored.This patch is needed for the Debian packaging.
 I'am not sure if the explicit check for the group id is really needed. Is it possible that setgid() returns zero on success but the group isnt correct set?

Reproduce on Debian:
- Get munin-c
  
  ```
  git clone https://github.com/munin-monitoring/munin-c.git 
  ```
- Install hardening-wrapper
  
  ```
  apt-get install hardening-wrapper 
  ```
- Set environment variable DEB_BUILD_HARDENING
  
  ```
  export DEB_BUILD_HARDENING=1
  ```
- Build munin-c
  
  ```
  autoreconf -i -I m4 && ./configure && make
  ```

<pre>
make[1]: Entering directory `/tmp/munin-c/src/node'
  CC       node.o
node.c: In function 'setenvvars_conf':
node.c:467:3: error: ignoring return value of 'setgid', declared with attribute warn_unused_result [-Werror=unused-result]
   (void)setgid(pconf.gid);
   ^
node.c:474:3: error: ignoring return value of 'setuid', declared with attribute warn_unused_result [-Werror=unused-result]
   (void)setuid(pconf.uid);
   ^
cc1: all warnings being treated as errors
make[1]: *** [node.o] Error 1
</pre>
