### PR TITLE
gitignore: handle .gdbinit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.1
 .deps
 .dirstamp
+.gdbinit
 tags
 TAGS
 /Makefile


### PR DESCRIPTION
We do not need personal gdb config in the source tree.
