### PR TITLE
Posix spawn

### DIFF
--- a/src/node/node.c
+++ b/src/node/node.c
@@ -26,10 +26,13 @@
 #include <grp.h>
 #include <fnmatch.h>
 #include <ctype.h>
+#include <spawn.h>
 
 #ifndef HOST_NAME_MAX
   #define HOST_NAME_MAX 256
 #endif
+
+extern char **environ;
 
 static const int yes = 1;
 static const int no = 0;
@@ -545,6 +548,7 @@ static int handle_connection() {
 				strcmp(cmd, "fetch") == 0
 			) {
 			char cmdline[LINE_MAX];
+			char *argv[2] = { 0, };
 			pid_t pid;
 			if(arg == NULL) {
 				printf("# no plugin given\n");
@@ -562,18 +566,23 @@ static int handle_connection() {
 				printf("# unknown plugin: %s\n", arg);
 				continue;
 			}
-			/* Using fork() here instead of vfork() since we will
+
+			/* Now is the time to set environnement */
+			setenvvars_conf(arg);
+			argv[0] = arg;
+
+			/* Using posix_spawnp() here instead of fork() since we will
 			 * do a little more than a mere exec --> setenvvars_conf() */
-			if(0 == (pid = fork())) {
-				/* Now is the time to set environnement */
-				setenvvars_conf(arg);
-				execl(cmdline, arg, cmd, NULL);
-				exit(1);
-			} else if(pid < 0) {
+			if (0 == posix_spawn(&pid, cmdline,
+					NULL, /* const posix_spawn_file_actions_t *file_actions, */
+					NULL, /* const posix_spawnattr_t *restrict attrp, */
+					argv, environ)) {
+
+				/* Wait for completion */
+				waitpid(pid, NULL, 0);
+			} else {
 				printf("# fork failed\n");
 				continue;
-			} else {
-				waitpid(pid, NULL, 0);
 			}
 			printf(".\n");
 		} else if (strcmp(cmd, "cap") == 0) {


### PR DESCRIPTION
posix_spawn() was meant to be used in the embedded world, as it requires
much less ressources to achieve its purpose.

In win32, fork() does not exist, and spawn() is quite limited. But we can emulate posix_spawn() much more easily than fork() with the CreateProcess() sys call as stated in MSDN.
 
> Use the Win32 API to create a pipe, then call AllocConsole, set the handle values in
> the startup structure, and call CreateProcess.
