### PR TITLE
Read enough bytes to avoid output truncation

### DIFF
--- a/src/plugins/threads.c
+++ b/src/plugins/threads.c
@@ -19,7 +19,7 @@
 
 int threads(int argc, char **argv) {
 	FILE *f;
-	char buff[512]; /* normally only 256 char are used, but gcc complains when sprintf %s is used */
+	char buff[270];
 	const char *s;
 	int i, sum;
 	DIR *d;
@@ -59,7 +59,7 @@ int threads(int argc, char **argv) {
 				break;
 		if(*s) /* non-digit found */
 			continue;
-		snprintf(buff, 256, "/proc/%s/status", e->d_name);
+		snprintf(buff, 270, "/proc/%s/status", e->d_name);
 		if(!(f = fopen(buff, "r")))
 			continue; /* process has vanished */
 		while(fgets(buff, 256, f)) {


### PR DESCRIPTION
With gcc-7 the option -Wformat-truncation can be used to warn about
possible output truncation when using snprintf() and vsnprintf().

The line in question here creates an output of max 269 bytes:  maximum
size of e->d_name (afaik 255 byte) plus the 13 bytes of the string "/proc//status" but
read only 256 byte into buf.

So increase the size of char buf[] and increase the number of bytes
read into buf silences the warning.

This fixes Debian #871108.

See
https://gcc.gnu.org/onlinedocs/gcc-7.2.0/gcc/Warning-Options.html#Warning-Options