### PR TITLE
Fix unused variable substitution in the manpage.

### DIFF
--- a/common.am
+++ b/common.am
@@ -3,5 +3,7 @@ RELEASE="$(shell $(top_srcdir)/getversion)"
 
 %.1:%.pod
 	$(AM_V_GEN)pod2man --section=1 --release=$(RELEASE) --center=$(MANCENTER) $< > $@
+	sed -i -e 's#@@pkglibexecdir@@#$(pkglibexecdir)#' -e 's#@@CONFDIR@@#$(sysconfdir)#' $@
+
 
 # vim:ft=make


### PR DESCRIPTION
The manpage munin-plugins-c.pod contained substitutions which where not
used. The missing values for the path to the plugins and the
configuration directory are added to manpage.
Fixes Debian bug #856660