### PR TITLE
Use file RELEASE as source for the version during build

### DIFF
--- a/getversion
+++ b/getversion
@@ -1,4 +1,12 @@
 #!/bin/sh
-# Revert to a *very* simple scheme
+#
+# Generate a version string for use when building.
+#
+# * If RELEASE exists, and is non-empty, use the contents of that file.
+#   This is in case we're building from a tarball.
 
-git describe --always
+if [ -s "RELEASE" ]; then
+    cat RELEASE
+else
+    git describe --always
+fi


### PR DESCRIPTION
That commit allows to build from tarball releases. This also fixes
Debian bug #845426 but without adding Debian specifics as proposed by
the reporter.

Older tarball releases of munin-c does not contained the file RELEASE even if
'getversion' in the past supported it (most likely because getversion
was copied from the Munin repository). So the release process needs
an additional step of adding the RELEASE file.