### PR TITLE
Use macro for printing uint64_t for better portability

### DIFF
--- a/src/plugins/cpu.c
+++ b/src/plugins/cpu.c
@@ -8,6 +8,7 @@
  */
 #include <stdbool.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -28,7 +29,7 @@ static int print_stat_value(const char* field_name, const char* stat_value, int 
 		/* hz_ is not ZERO, narmalize the value */
 		stat_value_ll = stat_value_ll * 100 / hz_;
 	}
-	return printf("%s.value %llu\n", field_name, stat_value_ll);
+	return printf("%s.value %"PRIu64"\n", field_name, stat_value_ll);
 }
 
 static int parse_cpu_line(char *buff) {


### PR DESCRIPTION
While compiling munin-c with gcc-7 on amd64 i get the following compiler warning/error: 

```
cpu.c: In function 'print_stat_value':
cpu.c:31:29: error: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Werror=format=]
  return printf("%s.value %llu\n", field_name, stat_value_ll);
                          ~~~^
                          %lu
cc1: all warnings being treated as errors
Makefile:432: recipe for target 'cpu.o' failed
```

On amd64 uint64_t is a "long unsigned". To avoid this portability trouble use the PRI.. macro defined in inttypes.h.