### PR TITLE
Enable munin-node-c to build and run on macOS/Darwin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,33 @@
+matrix:
+  include:
+    - os: osx
+      compiler: clang
+    - os: linux
+      compiler: gcc
+      env:
+        - LDFLAGS=
+    - os: linux
+      compiler: gcc
+      env:
+        - LDFLAGS=-static
+    - os: linux
+      compiler: clang
+      env:
+        - LDFLAGS=
+    - os: linux
+      compiler: clang
+      env:
+        - LDFLAGS=-static
+    - os: linux
+      compiler: musl-gcc
+      env:
+        - LDFLAGS=
+    - os: linux
+      compiler: musl-gcc
+      env:
+        - LDFLAGS=-static
+
 language: c
-compiler:
-  - gcc
-  - clang
-  - musl-gcc
 
 # Use a container Travis
 sudo: false
@@ -20,9 +45,6 @@ notifications:
 env:
   global:
     - secure: "CNXrpwGgWHhD9894gMeKqlt/5eeKJ+J764jRV685JWV/5OrHeWqEfAp+onX/B+RUCl5DrFpblyQl2K6IDTABolkY4Vy/kvZHB5Y2XhyXu3U6RzQwdH3xo9olJQ+UcGzNOc1YOqSWzkDG2JbR9HthgyWgMjbvePXn5AKRGUTAasI="
-  matrix:
-    - LDFLAGS=-static
-    - LDFLAGS=
 
 addons:
   apt:

--- a/common.am
+++ b/common.am
@@ -3,7 +3,7 @@ RELEASE="$(shell $(top_srcdir)/getversion)"
 
 %.1:%.pod
 	$(AM_V_GEN)pod2man --section=1 --release=$(RELEASE) --center=$(MANCENTER) $< > $@
-	sed -i -e 's#@@pkglibexecdir@@#$(pkglibexecdir)#' -e 's#@@CONFDIR@@#$(sysconfdir)#' $@
+	sed -i.bak -e 's#@@pkglibexecdir@@#$(pkglibexecdir)#' -e 's#@@CONFDIR@@#$(sysconfdir)#' $@
 
 
 # vim:ft=make

--- a/src/node/Makefile.am
+++ b/src/node/Makefile.am
@@ -11,7 +11,8 @@
 include $(top_srcdir)/common.am
 
 sbin_PROGRAMS = munin-node-c munin-inetd-c
-AM_CPPFLAGS = -DPLUGINDIR=\"$(sysconfdir)/munin/plugins\"
+AM_CPPFLAGS = -DPLUGINDIR=\"$(sysconfdir)/munin/plugins\" \
+              -DPLUGINCONFDIR=\"$(sysconfdir)/munin/plugin-conf.d\"
 munin_node_c_SOURCES = node.c
 munin_inetd_c_SOURCES = inetd.c
 man_MANS = munin-node-c.1

--- a/src/node/node.c
+++ b/src/node/node.c
@@ -45,7 +45,7 @@ static char* host = "";
 static char* plugin_dir = PLUGINDIR;
 static char* spoolfetch_dir = "";
 static char* client_ip = "-";
-static char* pluginconf_dir = "/etc/munin/plugin-conf.d";
+static char* pluginconf_dir = PLUGINCONFDIR;
 
 static int handle_connection();
 
@@ -416,7 +416,7 @@ static void setenvvars_conf(char* current_plugin_name) {
 	/* TODO - add plugin conf parsing */
 	DIR* dirp = opendir(pluginconf_dir);
 	if (dirp == NULL) {
-		printf("# Cannot open plugin config dir\n");
+		printf("# Cannot open plugin config dir '%s'\n", pluginconf_dir);
 		return;
 	}
 


### PR DESCRIPTION
A couple small changes that enable `munin-node-c` to build and run on macOS/Darwin.  Tested on OS X 10.10, macOS 10.13, and macOS 10.14.

(`munin-plugins-c` doesn't work yet, since that relies on `/proc` which doesn't exist on macOS.  But this PR enables `munin-node-c` to work with other plugins.)