### PR TITLE
Reformat source to match kernel coding style

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,19 @@ This project has been ported to autotools. You have to use::
 
     autoreconf -i -I m4 && ./configure && make
 
+
+
+Contribute and coding style
+===========================
+Contribute by open an issue or pull-request at
+https://github.com/munin-monitoring/munin-c
+
+When contributing code please follow the kernel coding style. 
+Use GNU indent with the parameters to follow the Kernighan & Ritchie coding
+style and set the indention level to 8 spaces::
+
+    find . -iname "*.c" -exec indent -kr -i8 {} \;
+
 License
 =======
 munin-c is licensed as gpl-2 or gpl-3 at your choice.

--- a/src/node/node.c
+++ b/src/node/node.c
@@ -29,7 +29,7 @@
 #include <spawn.h>
 
 #ifndef HOST_NAME_MAX
-  #define HOST_NAME_MAX 256
+#define HOST_NAME_MAX 256
 #endif
 
 extern char **environ;
@@ -41,21 +41,22 @@ static int is_acquire = 0;
 static int verbose = 0;
 static bool extension_stripping = false;
 
-static char* host = "";
-static char* plugin_dir = PLUGINDIR;
-static char* spoolfetch_dir = "";
-static char* client_ip = "-";
-static char* pluginconf_dir = PLUGINCONFDIR;
+static char *host = "";
+static char *plugin_dir = PLUGINDIR;
+static char *spoolfetch_dir = "";
+static char *client_ip = "-";
+static char *pluginconf_dir = PLUGINCONFDIR;
 
 static int handle_connection();
 
 #define xisspace(x) isspace((int)(unsigned char) x)
 #define xisdigit(x) isdigit((int)(unsigned char) x)
 
-static /*@noreturn@*/ void oom_handler() {
-	static const char* OOM_MSG = "Out of memory\n";
+static /*@noreturn@ */ void oom_handler()
+{
+	static const char *OOM_MSG = "Out of memory\n";
 
-	if ( write(STDOUT_FILENO, OOM_MSG, sizeof(OOM_MSG)-1) < 0) {
+	if (write(STDOUT_FILENO, OOM_MSG, sizeof(OOM_MSG) - 1) < 0) {
 		/* Do nothing on write failure, we are torched anyway */
 	}
 
@@ -65,68 +66,84 @@ static /*@noreturn@*/ void oom_handler() {
 
 /* an allocation bigger than MAX_ALLOC_SIZE is bogus */
 #define MAX_ALLOC_SIZE (16 * 1024 * 1024)
-static /*@only@*/ /*@out@*/ void *xmalloc(size_t size) {
-	void* ptr;
+static
+				    /*@only@ */
+ /*@out@ */
+void *xmalloc(size_t size)
+{
+	void *ptr;
 
 	assert(size < MAX_ALLOC_SIZE);
 
 	ptr = malloc(size);
-	if (ptr == NULL) oom_handler();
+	if (ptr == NULL)
+		oom_handler();
 	return ptr;
 }
 
-static /*@only@*/ char *xstrdup(const char* s) {
-	char* new_str;
+static /*@only@ */ char *xstrdup(const char *s)
+{
+	char *new_str;
 
 	assert(s != NULL);
 	assert(strlen(s) < MAX_ALLOC_SIZE);
 	new_str = strdup(s);
-	if (new_str == NULL) oom_handler();
+	if (new_str == NULL)
+		oom_handler();
 	return new_str;
 }
 
-static int xsetenv(const char *envname, const char *envval, int overwrite) {
-	if (verbose) printf("# Setting env %s = %s %s overwriting\n", envname, envval, overwrite ? "with" : "without");
+static int xsetenv(const char *envname, const char *envval, int overwrite)
+{
+	if (verbose)
+		printf("# Setting env %s = %s %s overwriting\n", envname,
+		       envval, overwrite ? "with" : "without");
 	return setenv(envname, envval, overwrite);
 }
 
-static int find_plugin_with_basename(/*@out@*/ char *cmdline,
-		const char *plugin_dir, const char *plugin_basename) {
-	DIR* dirp = opendir(plugin_dir);
-	struct dirent* dp;
+static int find_plugin_with_basename( /*@out@ */ char *cmdline,
+				     const char *plugin_dir,
+				     const char *plugin_basename)
+{
+	DIR *dirp = opendir(plugin_dir);
+	struct dirent *dp;
 	int found = 0;
 	size_t plugin_basename_len = strlen(plugin_basename);
 
 	if (dirp == NULL) {
 		perror("Cannot open plugin dir in " __FILE__);
-		return(found);
+		return (found);
 	}
 
 	/* Empty cmdline */
 	cmdline[0] = '\0';
 
 	while ((dp = readdir(dirp)) != NULL) {
-		char* plugin_filename = dp->d_name;
+		char *plugin_filename = dp->d_name;
 
 		if (plugin_filename[0] == '.') {
 			/* No dotted plugin */
 			continue;
 		}
 
-		if (strncmp(plugin_filename, plugin_basename, plugin_basename_len) != 0) {
+		if (strncmp
+		    (plugin_filename, plugin_basename,
+		     plugin_basename_len) != 0) {
 			/* Does not start with base */
 			continue;
 		}
 
-		if (plugin_filename[plugin_basename_len] != '\0' && plugin_filename[plugin_basename_len] != '.') {
+		if (plugin_filename[plugin_basename_len] != '\0'
+		    && plugin_filename[plugin_basename_len] != '.') {
 			/* Does not end the string or start an extension */
 			continue;
 		}
 
-		snprintf(cmdline, LINE_MAX, "%s/%s", plugin_dir, plugin_filename);
+		snprintf(cmdline, LINE_MAX, "%s/%s", plugin_dir,
+			 plugin_filename);
 		if (access(cmdline, X_OK) == 0) {
 			/* Found it */
-			found ++;
+			found++;
 			break;
 		}
 	}
@@ -139,7 +156,8 @@ static int find_plugin_with_basename(/*@out@*/ char *cmdline,
 int acquire_all();
 static void setenvvars_system(void);
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
 
 	int optch;
 
@@ -152,7 +170,7 @@ int main(int argc, char *argv[]) {
 	opterr = 1;
 
 	while ((optch = getopt(argc, argv, format)) != -1)
-	switch (optch) {
+		switch (optch) {
 		case 'a':
 			is_acquire = true;
 			break;
@@ -160,7 +178,7 @@ int main(int argc, char *argv[]) {
 			extension_stripping = true;
 			break;
 		case 'v':
-			verbose ++;
+			verbose++;
 			break;
 		case 'd':
 			plugin_dir = xstrdup(optarg);
@@ -174,7 +192,7 @@ int main(int argc, char *argv[]) {
 		case 's':
 			spoolfetch_dir = xstrdup(optarg);
 			break;
-	}
+		}
 
 	/* get default hostname if not precised */
 	if ('\0' == *host) {
@@ -193,18 +211,20 @@ int main(int argc, char *argv[]) {
 	setenvvars_system();
 
 	/* Asked to acquire */
-	if (is_acquire) return acquire_all();
+	if (is_acquire)
+		return acquire_all();
 
 	/* use a 1-shot stdin/stdout */
-	if(0 == getpeername(STDIN_FILENO, (struct sockaddr*)&client,
-				&client_len))
-		if(client.sin_family == AF_INET)
+	if (0 == getpeername(STDIN_FILENO, (struct sockaddr *) &client,
+			     &client_len))
+		if (client.sin_family == AF_INET)
 			client_ip = inet_ntoa(client.sin_addr);
 	return handle_connection();
 }
 
 /* Setting munin specific vars */
-static void setenvvars_system() {
+static void setenvvars_system()
+{
 	/* Some locales use "," as decimal separator.
 	 * This can mess up a lot of plugins. */
 	xsetenv("LC_ALL", "C", yes);
@@ -220,7 +240,8 @@ static void setenvvars_system() {
 }
 
 /* Setting munin specific vars */
-static void setenvvars_munin() {
+static void setenvvars_munin()
+{
 	/* munin-node will override this with the IP of the
 	 * connecting master */
 	if (client_ip != NULL && client_ip[0] != '\0') {
@@ -239,7 +260,11 @@ static void setenvvars_munin() {
 }
 
 /* in-place */
-static /*@null@*/ /*@exposed@*/ char *ltrim(/*@null@*/ char *s) {
+static
+				    /*@null@ */
+ /*@exposed@ */
+char *ltrim( /*@null@ */ char *s)
+{
 	if (s == NULL || *s == '\0') {
 		/* Empty string, returns unmodified */
 		return s;
@@ -253,8 +278,12 @@ static /*@null@*/ /*@exposed@*/ char *ltrim(/*@null@*/ char *s) {
 }
 
 /* in-place, but returns string for convenience */
-static /*@null@*/ /*@exposed@*/ char* rtrim(/*@null@*/ char* s) {
-	char* end;
+static
+				    /*@null@ */
+ /*@exposed@ */
+char *rtrim( /*@null@ */ char *s)
+{
+	char *end;
 
 	if (s == NULL || *s == '\0') {
 		/* Empty string, returns unmodified */
@@ -274,7 +303,10 @@ static /*@null@*/ /*@exposed@*/ char* rtrim(/*@null@*/ char* s) {
 }
 
 /* in-place */
-static /*@null@*/ /*@exposed@*/ char* trim(/*@null@*/ char* s)
+static
+				    /*@null@ */
+ /*@exposed@ */
+char *trim( /*@null@ */ char *s)
 {
 	s = ltrim(s);
 	s = rtrim(s);
@@ -297,19 +329,22 @@ struct s_plugin_conf {
 	struct s_env env[MAX_ENV_NB];
 };
 
-static void set_value(struct s_plugin_conf* conf, const char* key, const char* value) {
+static void set_value(struct s_plugin_conf *conf, const char *key,
+		      const char *value)
+{
 	size_t i;
 	size_t key_len = strlen(key);
 
-	struct s_env* dst_env = NULL;
+	struct s_env *dst_env = NULL;
 	/* Search for the corresponding env */
-	for (i = 0; i < conf->size; i ++) {
-		struct s_env* env = conf->env + i;
+	for (i = 0; i < conf->size; i++) {
+		struct s_env *env = conf->env + i;
 
-		if (key_len != env->key_len) continue;
+		if (key_len != env->key_len)
+			continue;
 
 		/* this cmp works since keys have the same length */
-		if(strncmp(key, env->buffer, env->key_len) != 0)
+		if (strncmp(key, env->buffer, env->key_len) != 0)
 			continue;
 
 		/* Found the key */
@@ -318,7 +353,7 @@ static void set_value(struct s_plugin_conf* conf, const char* key, const char* v
 
 	if (dst_env == NULL) {
 		/* Allocate one */
-		if(conf->size == MAX_ENV_NB) {
+		if (conf->size == MAX_ENV_NB) {
 			fprintf(stderr, "ran out of internal env space\n");
 			abort();
 		}
@@ -327,7 +362,7 @@ static void set_value(struct s_plugin_conf* conf, const char* key, const char* v
 		dst_env = conf->env;
 		dst_env += (int) conf->size;
 
-		conf->size ++;
+		conf->size++;
 	}
 
 	/* Save the environment in setenv() format */
@@ -335,20 +370,25 @@ static void set_value(struct s_plugin_conf* conf, const char* key, const char* v
 	snprintf(dst_env->buffer, MAX_ENV_BUF_SZ, "%s=%s", key, value);
 }
 
-static void end_before_first(char* s, char c) {
+static void end_before_first(char *s, char c)
+{
 	s = strchr(s, c);
-	if (s != NULL) *s = '\0';
+	if (s != NULL)
+		*s = '\0';
 }
 
-static struct s_plugin_conf* parse_plugin_conf(FILE* f, const char* plugin, struct s_plugin_conf* conf) {
+static struct s_plugin_conf *parse_plugin_conf(FILE * f,
+					       const char *plugin,
+					       struct s_plugin_conf *conf)
+{
 	/* read from file */
 	char line[LINE_MAX];
 	bool is_relevant = false;
 
 	while (fgets(line, LINE_MAX, f) != NULL) {
-		char* line_trimmed = trim(line);
+		char *line_trimmed = trim(line);
 		assert(line_trimmed != NULL);
-		if (line_trimmed[0] != '[' && ! is_relevant) {
+		if (line_trimmed[0] != '[' && !is_relevant) {
 			/* Ignore the line */
 			continue;
 		}
@@ -356,11 +396,13 @@ static struct s_plugin_conf* parse_plugin_conf(FILE* f, const char* plugin, stru
 		if (line_trimmed[0] == '[') {
 			line_trimmed++;
 			end_before_first(line_trimmed, ']');
-		
+
 			/* Try the key */
 			{
-				int fnmatch_flags = FNM_NOESCAPE | FNM_PATHNAME;
-				int res = fnmatch(line_trimmed, plugin, fnmatch_flags);
+				int fnmatch_flags =
+				    FNM_NOESCAPE | FNM_PATHNAME;
+				int res = fnmatch(line_trimmed, plugin,
+						  fnmatch_flags);
 				if (res == 0) {
 					is_relevant = true;
 				} else if (res == FNM_NOMATCH) {
@@ -370,41 +412,43 @@ static struct s_plugin_conf* parse_plugin_conf(FILE* f, const char* plugin, stru
 					abort();
 				}
 			}
-			
+
 			/* Next line */
 			continue;
 		}
 
 		{
-		/* Parse the line, and add it to the current conf */
-		char* key = trim(strtok(line_trimmed, " "));
-		char* value;
+			/* Parse the line, and add it to the current conf */
+			char *key = trim(strtok(line_trimmed, " "));
+			char *value;
 
-		/* No key found, skip the line */
-		if (key == NULL) continue;
+			/* No key found, skip the line */
+			if (key == NULL)
+				continue;
 
-		/* Everything after the first " " is value */
-		value = trim(key + strlen(key) + 1);
-		assert(value != NULL);
+			/* Everything after the first " " is value */
+			value = trim(key + strlen(key) + 1);
+			assert(value != NULL);
 
-		if (0 == strcmp(key, "user")) {
-			struct passwd* pswd = getpwnam(value);
-			if(pswd == NULL) {
-				perror("getpwnam() error");
-				abort();
+			if (0 == strcmp(key, "user")) {
+				struct passwd *pswd = getpwnam(value);
+				if (pswd == NULL) {
+					perror("getpwnam() error");
+					abort();
+				}
+				conf->uid = pswd->pw_uid;
+			} else if (0 == strcmp(key, "group")) {
+				struct group *grp = getgrnam(value);
+				if (grp == NULL) {
+					perror("getgrnam() error");
+					abort();
+				}
+				conf->gid = grp->gr_gid;
+			} else if (0 ==
+				   strncmp(key, "env.", strlen("env."))) {
+				char *env_key = key + strlen("env.");
+				set_value(conf, env_key, value);
 			}
-			conf->uid = pswd->pw_uid;
-		} else if (0 == strcmp(key, "group")) {
-			struct group* grp = getgrnam(value);
-			if(grp == NULL) {
-				perror("getgrnam() error");
-				abort();
-			}
-			conf->gid = grp->gr_gid;
-		} else if (0 == strncmp(key, "env.", strlen("env."))) {
-			char *env_key = key + strlen("env.");
-			set_value(conf, env_key, value);
-		}
 		}
 	}
 
@@ -412,93 +456,103 @@ static struct s_plugin_conf* parse_plugin_conf(FILE* f, const char* plugin, stru
 }
 
 /* Setting user configured vars */
-static void setenvvars_conf(char* current_plugin_name) {
+static void setenvvars_conf(char *current_plugin_name)
+{
 	/* TODO - add plugin conf parsing */
-	DIR* dirp = opendir(pluginconf_dir);
+	DIR *dirp = opendir(pluginconf_dir);
 	if (dirp == NULL) {
-		printf("# Cannot open plugin config dir '%s'\n", pluginconf_dir);
+		printf("# Cannot open plugin config dir '%s'\n",
+		       pluginconf_dir);
 		return;
 	}
 
 	{
-	struct s_plugin_conf pconf;
-	pconf.size = 0;
+		struct s_plugin_conf pconf;
+		pconf.size = 0;
 
-	/* default is nobody:nobody */
-	{
-		struct passwd* pswd = getpwnam("nobody");
-		if(pswd == NULL) {
-			perror("getpwnam(\"nobody\") error");
-			abort();
-		}
-		pconf.uid = pswd->pw_uid;
-	}
-	{
-		struct group* grp = getgrnam("nogroup");
-		if(grp == NULL) {
-			perror("getgrnam(\"nogroup\") error");
-			abort();
-		}
-		pconf.gid = grp->gr_gid;
-	}
-
-	{
-	struct dirent* dp;
-	while ((dp = readdir(dirp)) != NULL) {
-		char cmdline[LINE_MAX];
-		char* plugin_filename = dp->d_name;;
-
-		if (plugin_filename[0] == '.') {
-			/* No dotted plugin */
-			continue;
-		}
-
-		snprintf(cmdline, LINE_MAX, "%s/%s", pluginconf_dir, plugin_filename);
+		/* default is nobody:nobody */
 		{
-		FILE* f = fopen(cmdline, "r");
-		if (f == NULL) {
-			/* Ignore open failures */
-			continue;
-		}
-
-		parse_plugin_conf(f, current_plugin_name, &pconf);
-
-		fclose(f);
-		}
-	}
-
-	/* Set env after whole parsing */
-	{
-	size_t i;
-	for (i = 0; i < pconf.size; i ++) {
-		struct s_env* env = pconf.env + i;
-		putenv(env->buffer);
-	}
-	}
-
-	/* setuid/gid */
-	if (geteuid() == 0) {
-		/* We *are* root */
-		int ret_val;
-		ret_val = setgid(pconf.gid);
-		if ((ret_val != 0) || (getgid() != pconf.gid)) {
-				perror("gid not changed by setgid");
+			struct passwd *pswd = getpwnam("nobody");
+			if (pswd == NULL) {
+				perror("getpwnam(\"nobody\") error");
 				abort();
+			}
+			pconf.uid = pswd->pw_uid;
+		}
+		{
+			struct group *grp = getgrnam("nogroup");
+			if (grp == NULL) {
+				perror("getgrnam(\"nogroup\") error");
+				abort();
+			}
+			pconf.gid = grp->gr_gid;
 		}
 
-		/* Change UID *after* GID, otherwise cannot change anymore */
-		ret_val = setuid(pconf.uid);
-		if ((ret_val != 0) || (getuid() != pconf.uid)) {
-			perror("uid not changed by setuid");
-			abort();
+		{
+			struct dirent *dp;
+			while ((dp = readdir(dirp)) != NULL) {
+				char cmdline[LINE_MAX];
+				char *plugin_filename = dp->d_name;;
+
+				if (plugin_filename[0] == '.') {
+					/* No dotted plugin */
+					continue;
+				}
+
+				snprintf(cmdline, LINE_MAX, "%s/%s",
+					 pluginconf_dir, plugin_filename);
+				{
+					FILE *f = fopen(cmdline, "r");
+					if (f == NULL) {
+						/* Ignore open failures */
+						continue;
+					}
+
+					parse_plugin_conf(f,
+							  current_plugin_name,
+							  &pconf);
+
+					fclose(f);
+				}
+			}
+
+			/* Set env after whole parsing */
+			{
+				size_t i;
+				for (i = 0; i < pconf.size; i++) {
+					struct s_env *env = pconf.env + i;
+					putenv(env->buffer);
+				}
+			}
+
+			/* setuid/gid */
+			if (geteuid() == 0) {
+				/* We *are* root */
+				int ret_val;
+				ret_val = setgid(pconf.gid);
+				if ((ret_val != 0)
+				    || (getgid() != pconf.gid)) {
+					perror
+					    ("gid not changed by setgid");
+					abort();
+				}
+
+				/* Change UID *after* GID, otherwise cannot change anymore */
+				ret_val = setuid(pconf.uid);
+				if ((ret_val != 0)
+				    || (getuid() != pconf.uid)) {
+					perror
+					    ("uid not changed by setuid");
+					abort();
+				}
+			}
 		}
-	}
-	}
 	}
 	closedir(dirp);
 }
 
-static int handle_connection() {
+static int handle_connection()
+{
 	char line[LINE_MAX];
 
 	/* Prepare per connection plugin env vars */
@@ -506,11 +560,11 @@ static int handle_connection() {
 
 	printf("# munin node at %s\n", host);
 	while (fflush(stdout), fgets(line, LINE_MAX, stdin) != NULL) {
-		char* cmd;
-		char* arg;
+		char *cmd;
+		char *arg;
 
 		cmd = strtok(line, " \t\n\r");
-		if(cmd == NULL)
+		if (cmd == NULL)
 			arg = NULL;
 		else
 			arg = strtok(NULL, " \t\n\r");
@@ -523,56 +577,68 @@ static int handle_connection() {
 			printf("%s\n", host);
 			printf(".\n");
 		} else if (strcmp(cmd, "quit") == 0) {
-			return(0);
+			return (0);
 		} else if (strcmp(cmd, "list") == 0) {
-			DIR* dirp = opendir(plugin_dir);
+			DIR *dirp = opendir(plugin_dir);
 			if (dirp == NULL) {
 				printf("# Cannot open plugin dir\n");
-				return(0);
+				return (0);
 			}
 			{
-			struct dirent* dp;
-			while ((dp = readdir(dirp)) != NULL) {
-				char cmdline[LINE_MAX];
-				char* plugin_filename = dp->d_name;;
+				struct dirent *dp;
+				while ((dp = readdir(dirp)) != NULL) {
+					char cmdline[LINE_MAX];
+					char *plugin_filename =
+					    dp->d_name;;
 
-				if (plugin_filename[0] == '.') {
-					/* No dotted plugin */
-					continue;
-				}
-
-				snprintf(cmdline, LINE_MAX, "%s/%s", plugin_dir, plugin_filename);
-				if (access(cmdline, X_OK) == 0) {
-					if(extension_stripping) {
-						/* Strip after the last . */
-						char *last_dot_idx = strrchr(plugin_filename, '.');
-						if (last_dot_idx != NULL) {
-							*last_dot_idx = '\0';
-						}
+					if (plugin_filename[0] == '.') {
+						/* No dotted plugin */
+						continue;
 					}
-					printf("%s ", plugin_filename);
+
+					snprintf(cmdline, LINE_MAX,
+						 "%s/%s", plugin_dir,
+						 plugin_filename);
+					if (access(cmdline, X_OK) == 0) {
+						if (extension_stripping) {
+							/* Strip after the last . */
+							char *last_dot_idx
+							    =
+							    strrchr
+							    (plugin_filename,
+							     '.');
+							if (last_dot_idx !=
+							    NULL) {
+								*last_dot_idx
+								    = '\0';
+							}
+						}
+						printf("%s ",
+						       plugin_filename);
+					}
 				}
-			}
-			closedir(dirp);
+				closedir(dirp);
 			}
 			putchar('\n');
-		} else if (
-				strcmp(cmd, "config") == 0 ||
-				strcmp(cmd, "fetch") == 0
-			) {
+		} else if (strcmp(cmd, "config") == 0 ||
+			   strcmp(cmd, "fetch") == 0) {
 			char cmdline[LINE_MAX];
 			pid_t pid;
-			if(arg == NULL) {
+			if (arg == NULL) {
 				printf("# no plugin given\n");
 				continue;
 			}
-			if(arg[0] == '.' || strchr(arg, '/') != NULL) {
+			if (arg[0] == '.' || strchr(arg, '/') != NULL) {
 				printf("# invalid plugin character\n");
 				continue;
 			}
-			if (! extension_stripping || find_plugin_with_basename(cmdline, plugin_dir, arg) == 0) {
+			if (!extension_stripping
+			    || find_plugin_with_basename(cmdline,
+							 plugin_dir,
+							 arg) == 0) {
 				/* extension_stripping failed, using the plain method */
-				snprintf(cmdline, LINE_MAX, "%s/%s", plugin_dir, arg);
+				snprintf(cmdline, LINE_MAX, "%s/%s",
+					 plugin_dir, arg);
 			}
 			if (access(cmdline, X_OK) == -1) {
 				printf("# unknown plugin: %s\n", arg);
@@ -604,48 +670,53 @@ static int handle_connection() {
 		} else if (strcmp(cmd, "spoolfetch") == 0) {
 			printf("# not implem yet cmd: %s\n", cmd);
 		} else {
-			printf("# Unknown cmd: %s. Try cap, list, nodes, config, fetch, version or quit\n", cmd);
+			printf
+			    ("# Unknown cmd: %s. Try cap, list, nodes, config, fetch, version or quit\n",
+			     cmd);
 		}
 	}
 
 	return 0;
 }
 
-pid_t acquire(char* plugin_name, char *plugin_filename);
+pid_t acquire(char *plugin_name, char *plugin_filename);
 
-int acquire_all() {
-	DIR* dirp = opendir(plugin_dir);
+int acquire_all()
+{
+	DIR *dirp = opendir(plugin_dir);
 	if (dirp == NULL) {
 		printf("# Cannot open plugin dir\n");
-		return(0);
+		return (0);
 	}
 	{
-	struct dirent* dp;
-	while ((dp = readdir(dirp)) != NULL) {
-		char cmdline[LINE_MAX];
-		char* plugin_filename = dp->d_name;;
+		struct dirent *dp;
+		while ((dp = readdir(dirp)) != NULL) {
+			char cmdline[LINE_MAX];
+			char *plugin_filename = dp->d_name;;
 
-		if (plugin_filename[0] == '.') {
-			/* No dotted plugin */
-			continue;
-		}
-
-		snprintf(cmdline, LINE_MAX, "%s/%s", plugin_dir, plugin_filename);
-		if (access(cmdline, X_OK) == 0) {
-			if(extension_stripping) {
-				/* Strip after the last . */
-				char *last_dot_idx = strrchr(plugin_filename, '.');
-				if (last_dot_idx != NULL) {
-					*last_dot_idx = '\0';
-				}
+			if (plugin_filename[0] == '.') {
+				/* No dotted plugin */
+				continue;
 			}
 
-			/* run acquire on that */
-			printf("# acquire %s\n", plugin_filename);
-			acquire(plugin_filename, cmdline);
+			snprintf(cmdline, LINE_MAX, "%s/%s", plugin_dir,
+				 plugin_filename);
+			if (access(cmdline, X_OK) == 0) {
+				if (extension_stripping) {
+					/* Strip after the last . */
+					char *last_dot_idx =
+					    strrchr(plugin_filename, '.');
+					if (last_dot_idx != NULL) {
+						*last_dot_idx = '\0';
+					}
+				}
+
+				/* run acquire on that */
+				printf("# acquire %s\n", plugin_filename);
+				acquire(plugin_filename, cmdline);
+			}
 		}
-	}
-	closedir(dirp);
+		closedir(dirp);
 	}
 
 	/* wait for all childrens to end */
@@ -657,10 +728,12 @@ int acquire_all() {
 	return 0;
 }
 
-pid_t acquire(char* plugin_name, char *plugin_filename) {
+pid_t acquire(char *plugin_name, char *plugin_filename)
+{
 	/* continue in background */
 	pid_t child = fork();
-	if (child) return child;
+	if (child)
+		return child;
 
 	setenvvars_munin();
 	setenvvars_conf(plugin_name);

--- a/src/plugins/common.c
+++ b/src/plugins/common.c
@@ -36,7 +36,7 @@ int getenvint(const char *name, int defvalue) {
 	return atoi(value);
 }
 
-/*@null@*/ /*@observer@*/ const char *getenv_composed(const char *name1,
+static /*@null@*/ /*@observer@*/ const char *getenv_composed(const char *name1,
 		const char *name2) {
 	char **p;
 	size_t len1 = strlen(name1), len2 = strlen(name2);

--- a/src/plugins/common.c
+++ b/src/plugins/common.c
@@ -14,13 +14,15 @@
 
 extern char **environ;
 
-int writeyes(void) {
+int writeyes(void)
+{
 	puts("yes");
 	return 0;
 }
 
-int autoconf_check_readable(const char *path) {
-	if(0 == access(path, R_OK))
+int autoconf_check_readable(const char *path)
+{
+	if (0 == access(path, R_OK))
 		return writeyes();
 	else {
 		printf("no (%s is not readable, errno=%d)\n", path, errno);
@@ -28,55 +30,63 @@ int autoconf_check_readable(const char *path) {
 	}
 }
 
-int getenvint(const char *name, int defvalue) {
+int getenvint(const char *name, int defvalue)
+{
 	const char *value;
 	value = getenv(name);
-	if(value == NULL)
+	if (value == NULL)
 		return defvalue;
 	return atoi(value);
 }
 
-static /*@null@*/ /*@observer@*/ const char *getenv_composed(const char *name1,
-		const char *name2) {
+static
+				    /*@null@ */
+ /*@observer@ */
+const char *getenv_composed(const char *name1, const char *name2)
+{
 	char **p;
 	size_t len1 = strlen(name1), len2 = strlen(name2);
-	for(p = environ; *p; ++p) {
-		if(0 == strncmp(*p, name1, len1) &&
-				0 == strncmp(len1 + *p, name2, len2) &&
-				(*p)[len1 + len2] == '=')
+	for (p = environ; *p; ++p) {
+		if (0 == strncmp(*p, name1, len1) &&
+		    0 == strncmp(len1 + *p, name2, len2) &&
+		    (*p)[len1 + len2] == '=')
 			return len1 + len2 + 1 + *p;
 	}
 	return NULL;
 }
 
-void print_warning(const char *name) {
+void print_warning(const char *name)
+{
 	const char *p;
 	p = getenv_composed(name, "_warning");
-	if(p == NULL)
+	if (p == NULL)
 		p = getenv("warning");
-	if(p == NULL)
+	if (p == NULL)
 		return;
 
 	printf("%s.warning %s\n", name, p);
 }
 
-void print_critical(const char *name) {
+void print_critical(const char *name)
+{
 	const char *p;
 	p = getenv_composed(name, "_critical");
-	if(p == NULL)
+	if (p == NULL)
 		p = getenv("critical");
-	if(p == NULL)
+	if (p == NULL)
 		return;
 
 	printf("%s.critical %s\n", name, p);
 }
 
-void print_warncrit(const char *name) {
+void print_warncrit(const char *name)
+{
 	print_warning(name);
 	print_critical(name);
 }
 
-int fail(const char *message) {
+int fail(const char *message)
+{
 	fputs(message, stderr);
 	fputc('\n', stderr);
 	return 1;

--- a/src/plugins/common.h
+++ b/src/plugins/common.h
@@ -23,11 +23,6 @@ int autoconf_check_readable(const char *);
  * variable the given defaultvalue is returned.  */
 int getenvint(const char *, int defaultvalue);
 
-/** Return the value of the environment variable referred to by the
- * concatenation of the given strings.  */
-/*@null@*/ /*@observer@*/ const char *getenv_composed(const char *,
-		const char *);
-
 /** Print a name.warning line using the "name_warning" or "warning" environment
  * variables. */
 void print_warning(const char *name);

--- a/src/plugins/entropy.c
+++ b/src/plugins/entropy.c
@@ -13,28 +13,29 @@
 
 #define ENTROPY_AVAIL "/proc/sys/kernel/random/entropy_avail"
 
-int entropy(int argc, char **argv) {
+int entropy(int argc, char **argv)
+{
 	FILE *f;
 	int entropy;
-	if(argc > 1) {
-		if(!strcmp(argv[1], "config")) {
+	if (argc > 1) {
+		if (!strcmp(argv[1], "config")) {
 			puts("graph_title Available entropy\n"
-				"graph_args --base 1000 -l 0\n"
-				"graph_vlabel entropy (bytes)\n"
-				"graph_scale no\n"
-				"graph_category system\n"
-				"graph_info This graph shows the amount of entropy available in the system.\n"
-				"entropy.label entropy\n"
-				"entropy.info The number of random bytes available. This is typically used by cryptographic applications.");
+			     "graph_args --base 1000 -l 0\n"
+			     "graph_vlabel entropy (bytes)\n"
+			     "graph_scale no\n"
+			     "graph_category system\n"
+			     "graph_info This graph shows the amount of entropy available in the system.\n"
+			     "entropy.label entropy\n"
+			     "entropy.info The number of random bytes available. This is typically used by cryptographic applications.");
 			print_warncrit("entropy");
 			return 0;
 		}
-		if(!strcmp(argv[1], "autoconf"))
+		if (!strcmp(argv[1], "autoconf"))
 			return autoconf_check_readable(ENTROPY_AVAIL);
 	}
-	if(!(f=fopen(ENTROPY_AVAIL, "r")))
+	if (!(f = fopen(ENTROPY_AVAIL, "r")))
 		return fail("cannot open " ENTROPY_AVAIL);
-	if(1 != fscanf(f, "%d", &entropy)) {
+	if (1 != fscanf(f, "%d", &entropy)) {
 		fclose(f);
 		return fail("cannot read from " ENTROPY_AVAIL);
 	}

--- a/src/plugins/external_.c
+++ b/src/plugins/external_.c
@@ -15,12 +15,13 @@
 #include "common.h"
 #include "plugins.h"
 
-static int read_file_to_stdout(const char *filename) {
+static int read_file_to_stdout(const char *filename)
+{
 	FILE *f;
 	int c;
 
-	if(!(f=fopen(filename, "r"))) {
-		fputs("cannot open ", stderr); /* filename is not a constant */
+	if (!(f = fopen(filename, "r"))) {
+		fputs("cannot open ", stderr);	/* filename is not a constant */
 		return fail(filename);
 	}
 
@@ -33,28 +34,34 @@ static int read_file_to_stdout(const char *filename) {
 	return 0;
 }
 
-static int set_filename(char *filename, const char* plugin_basename, const char *action) {
+static int set_filename(char *filename, const char *plugin_basename,
+			const char *action)
+{
 
 	if (getenv(action) == NULL) {
 		/* Default */
-		return snprintf(filename, LINE_MAX, "%s/%s.%s", getenv("MUNIN_PLUGSTATE"), plugin_basename, action);
+		return snprintf(filename, LINE_MAX, "%s/%s.%s",
+				getenv("MUNIN_PLUGSTATE"), plugin_basename,
+				action);
 	}
 
 	return snprintf(filename, LINE_MAX, "%s", getenv(action));
 }
 
-int external_(int argc, char **argv) {
+int external_(int argc, char **argv)
+{
 	char filename[LINE_MAX];
 
 	/* Default is "fetch" */
 	set_filename(filename, basename(argv[0]), "fetch");
 
-	if(argc > 1) {
-		if(!strcmp(argv[1], "autoconf"))
+	if (argc > 1) {
+		if (!strcmp(argv[1], "autoconf"))
 			return puts("no (not yet implemented)");
 
-		if(!strcmp(argv[1], "config")) {
-			set_filename(filename, basename(argv[0]), "config");
+		if (!strcmp(argv[1], "config")) {
+			set_filename(filename, basename(argv[0]),
+				     "config");
 		}
 	}
 

--- a/src/plugins/forks.c
+++ b/src/plugins/forks.c
@@ -14,33 +14,34 @@
 #include "common.h"
 #include "plugins.h"
 
-int forks(int argc, char **argv) {
+int forks(int argc, char **argv)
+{
 	FILE *f;
 	char buff[256];
-	if(argc > 1) {
-		if(!strcmp(argv[1], "config")) {
+	if (argc > 1) {
+		if (!strcmp(argv[1], "config")) {
 			puts("graph_title Fork rate\n"
-				"graph_args --base 1000 -l 0 \n"
-				"graph_vlabel forks / ${graph_period}\n"
-				"graph_category processes\n"
-				"graph_info This graph shows the forking rate (new processes started).\n"
-				"forks.label forks\n"
-				"forks.type DERIVE\n"
-				"forks.min 0\n"
-				"forks.max 100000\n"
-				"forks.info The number of forks per second.");
+			     "graph_args --base 1000 -l 0 \n"
+			     "graph_vlabel forks / ${graph_period}\n"
+			     "graph_category processes\n"
+			     "graph_info This graph shows the forking rate (new processes started).\n"
+			     "forks.label forks\n"
+			     "forks.type DERIVE\n"
+			     "forks.min 0\n"
+			     "forks.max 100000\n"
+			     "forks.info The number of forks per second.");
 			print_warncrit("forks");
 			return 0;
 		}
-		if(!strcmp(argv[1], "autoconf"))
+		if (!strcmp(argv[1], "autoconf"))
 			return autoconf_check_readable(PROC_STAT);
 	}
-	if(!(f=fopen(PROC_STAT, "r")))
+	if (!(f = fopen(PROC_STAT, "r")))
 		return fail("cannot open " PROC_STAT);
-	while(fgets(buff, 256, f)) {
-		if(!strncmp(buff, "processes ", 10)) {
+	while (fgets(buff, 256, f)) {
+		if (!strncmp(buff, "processes ", 10)) {
 			fclose(f);
-			printf("forks.value %s", buff+10);
+			printf("forks.value %s", buff + 10);
 			return 0;
 		}
 	}

--- a/src/plugins/fw_packets.c
+++ b/src/plugins/fw_packets.c
@@ -14,45 +14,45 @@
 
 #define PROC_NET_SNMP "/proc/net/snmp"
 
-int fw_packets(int argc, char **argv) {
+int fw_packets(int argc, char **argv)
+{
 	FILE *f;
 	char buff[1024], *s;
 	int ret;
-	if(argc > 1) {
-		if(!strcmp(argv[1], "config")) {
+	if (argc > 1) {
+		if (!strcmp(argv[1], "config")) {
 			puts("graph_title Firewall Throughput\n"
-				"graph_args --base 1000 -l 0\n"
-				"graph_vlabel Packets/${graph_period}\n"
-				"graph_category network\n"
-				"received.label Received\n"
-				"received.draw AREA\n"
-				"received.type DERIVE\n"
-				"received.min 0\n"
-				"forwarded.label Forwarded\n"
-				"forwarded.draw LINE2\n"
-				"forwarded.type DERIVE\n"
-				"forwarded.min 0");
+			     "graph_args --base 1000 -l 0\n"
+			     "graph_vlabel Packets/${graph_period}\n"
+			     "graph_category network\n"
+			     "received.label Received\n"
+			     "received.draw AREA\n"
+			     "received.type DERIVE\n"
+			     "received.min 0\n"
+			     "forwarded.label Forwarded\n"
+			     "forwarded.draw LINE2\n"
+			     "forwarded.type DERIVE\n" "forwarded.min 0");
 			return 0;
 		}
-		if(!strcmp(argv[1], "autoconf"))
+		if (!strcmp(argv[1], "autoconf"))
 			return autoconf_check_readable(PROC_NET_SNMP);
 	}
-	if(!(f=fopen(PROC_NET_SNMP, "r")))
+	if (!(f = fopen(PROC_NET_SNMP, "r")))
 		return fail("cannot open " PROC_NET_SNMP);
-	while(fgets(buff, 1024, f)) {
-		if(!strncmp(buff, "Ip: ", 4) && xisdigit(buff[4])) {
-			if(!(s = strtok(buff+4, " \t")))
+	while (fgets(buff, 1024, f)) {
+		if (!strncmp(buff, "Ip: ", 4) && xisdigit(buff[4])) {
+			if (!(s = strtok(buff + 4, " \t")))
 				break;
-			if(!(s = strtok(NULL, " \t")))
+			if (!(s = strtok(NULL, " \t")))
 				break;
-			if(!(s = strtok(NULL, " \t")))
+			if (!(s = strtok(NULL, " \t")))
 				break;
 			printf("received.value %s\n", s);
-			if(!(s = strtok(NULL, " \t")))
+			if (!(s = strtok(NULL, " \t")))
 				break;
-			if(!(s = strtok(NULL, " \t")))
+			if (!(s = strtok(NULL, " \t")))
 				break;
-			if(!(s = strtok(NULL, " \t")))
+			if (!(s = strtok(NULL, " \t")))
 				break;
 			printf("forwarded.value %s\n", s);
 			ret = 0;
@@ -60,7 +60,7 @@ int fw_packets(int argc, char **argv) {
 		}
 	}
 	ret = fail("no ip line found in " PROC_NET_SNMP);
-OK:
+      OK:
 	fclose(f);
 	return ret;
 }

--- a/src/plugins/if_err_.c
+++ b/src/plugins/if_err_.c
@@ -15,7 +15,8 @@
 
 #define PROC_NET_DEV "/proc/net/dev"
 
-int if_err_(int argc, char **argv) {
+int if_err_(int argc, char **argv)
+{
 	char *interface;
 	size_t interface_len;
 	FILE *f;
@@ -23,100 +24,93 @@ int if_err_(int argc, char **argv) {
 	int i;
 
 	interface = basename(argv[0]);
-	if(strncmp(interface, "if_err_", 7) != 0)
+	if (strncmp(interface, "if_err_", 7) != 0)
 		return fail("if_err_ invoked with invalid basename");
 	interface += 7;
 	interface_len = strlen(interface);
 
-	if(argc > 1) {
-		if(!strcmp(argv[1], "autoconf"))
+	if (argc > 1) {
+		if (!strcmp(argv[1], "autoconf"))
 			return autoconf_check_readable(PROC_NET_DEV);
-		if(!strcmp(argv[1], "suggest")) {
-			if(NULL == (f = fopen(PROC_NET_DEV, "r")))
+		if (!strcmp(argv[1], "suggest")) {
+			if (NULL == (f = fopen(PROC_NET_DEV, "r")))
 				return 1;
-			while(fgets(buff, 256, f)) {
-				for(s=buff;*s == ' ';++s)
-					;
+			while (fgets(buff, 256, f)) {
+				for (s = buff; *s == ' '; ++s);
 				i = 0;
-				if(!strncmp(s, "lo:", 3))
+				if (!strncmp(s, "lo:", 3))
 					continue;
-				if(!strncmp(s, "sit", 3)) {
-					for(i=3; xisdigit(s[i]); ++i)
-						;
-					if(s[i] == ':')
+				if (!strncmp(s, "sit", 3)) {
+					for (i = 3; xisdigit(s[i]); ++i);
+					if (s[i] == ':')
 						continue;
 				}
-				while(s[i] != ':' && s[i] != '\0')
+				while (s[i] != ':' && s[i] != '\0')
 					++i;
-				if(s[i] != ':')
-					continue; /* a header line */
+				if (s[i] != ':')
+					continue;	/* a header line */
 				s[i] = '\0';
 				puts(s);
 			}
 			fclose(f);
 			return 0;
 		}
-		if(!strcmp(argv[1], "config")) {
+		if (!strcmp(argv[1], "config")) {
 			puts("graph_order rcvd trans");
 			printf("graph_title %s errors\n", interface);
 			puts("graph_args --base 1000\n"
-				"graph_vlabel packets in (-) / out (+) per "
-					"${graph_period}\n"
-				"graph_category network");
+			     "graph_vlabel packets in (-) / out (+) per "
+			     "${graph_period}\n" "graph_category network");
 			printf("graph_info This graph shows the amount of "
-				"errors on the %s network interface.\n",
-				interface);
+			       "errors on the %s network interface.\n",
+			       interface);
 			puts("rcvd.label packets\n"
-				"rcvd.type COUNTER\n"
-				"rcvd.graph no\n"
-				"rcvd.warning 1\n"
-				"trans.label packets\n"
-				"trans.type COUNTER\n"
-				"trans.negative rcvd\n"
-				"trans.warning 1");
+			     "rcvd.type COUNTER\n"
+			     "rcvd.graph no\n"
+			     "rcvd.warning 1\n"
+			     "trans.label packets\n"
+			     "trans.type COUNTER\n"
+			     "trans.negative rcvd\n" "trans.warning 1");
 			print_warncrit("rcvd");
 			print_warncrit("trans");
 			return 0;
 		}
 	}
-	if(NULL == (f = fopen(PROC_NET_DEV, "r")))
+	if (NULL == (f = fopen(PROC_NET_DEV, "r")))
 		return 1;
-	while(fgets(buff, 256, f)) {
-		for(s=buff;*s == ' ';++s)
-			;
-		if(0 != strncmp(s, interface, interface_len))
+	while (fgets(buff, 256, f)) {
+		for (s = buff; *s == ' '; ++s);
+		if (0 != strncmp(s, interface, interface_len))
 			continue;
 		s += interface_len;
-		if(*s != ':')
+		if (*s != ':')
 			continue;
 		++s;
 
-		while(*s == ' ')
+		while (*s == ' ')
 			++s;
 
-		for(i=1;i<3;++i) {
-			while(xisdigit(*s))
+		for (i = 1; i < 3; ++i) {
+			while (xisdigit(*s))
 				++s;
-			while(xisspace(*s))
+			while (xisspace(*s))
 				++s;
 		}
-		for(i=0;xisdigit(s[i]);++i)
-			;
+		for (i = 0; xisdigit(s[i]); ++i);
 		printf("rcvd.value ");
 		fwrite(s, 1, i, stdout);
 		putchar('\n');
 		s += i;
-		while(xisspace(*s))
+		while (xisspace(*s))
 			++s;
 
-		for(i=4;i<11;++i) {
-			while(xisdigit(*s))
+		for (i = 4; i < 11; ++i) {
+			while (xisdigit(*s))
 				++s;
-			while(xisspace(*s))
+			while (xisspace(*s))
 				++s;
 		}
-		for(i=0;xisdigit(s[i]);++i)
-			;
+		for (i = 0; xisdigit(s[i]); ++i);
 		printf("trans.value ");
 		fwrite(s, 1, i, stdout);
 		putchar('\n');

--- a/src/plugins/interrupts.c
+++ b/src/plugins/interrupts.c
@@ -14,42 +14,30 @@
 #include "common.h"
 #include "plugins.h"
 
-int interrupts(int argc, char **argv) {
+int interrupts(int argc, char **argv)
+{
 	FILE *f;
 	char buff[256];
-	if(argc > 1) {
-		if(!strcmp(argv[1], "config")) {
-			puts("graph_title Interrupts and context switches\n"
-				"graph_args --base 1000 -l 0\n"
-				"graph_vlabel interrupts & ctx switches / ${graph_period}\n"
-				"graph_category system\n"
-				"graph_info This graph shows the number of interrupts and context switches on the system. These are typically high on a busy system.\n"
-				"intr.info Interrupts are events that alter sequence of instructions executed by a processor. They can come from either hardware (exceptions, NMI, IRQ) or software.");
-			puts("ctx.info A context switch occurs when a multitasking operatings system suspends the currently running process, and starts executing another.\n"
-				"intr.label interrupts\n"
-				"ctx.label context switches\n"
-				"intr.type DERIVE\n"
-				"ctx.type DERIVE\n"
-				"intr.max 100000\n"
-				"ctx.max 100000\n"
-				"intr.min 0\n"
-				"ctx.min 0");
+	if (argc > 1) {
+		if (!strcmp(argv[1], "config")) {
+			puts("graph_title Interrupts and context switches\n" "graph_args --base 1000 -l 0\n" "graph_vlabel interrupts & ctx switches / ${graph_period}\n" "graph_category system\n" "graph_info This graph shows the number of interrupts and context switches on the system. These are typically high on a busy system.\n" "intr.info Interrupts are events that alter sequence of instructions executed by a processor. They can come from either hardware (exceptions, NMI, IRQ) or software.");
+			puts("ctx.info A context switch occurs when a multitasking operatings system suspends the currently running process, and starts executing another.\n" "intr.label interrupts\n" "ctx.label context switches\n" "intr.type DERIVE\n" "ctx.type DERIVE\n" "intr.max 100000\n" "ctx.max 100000\n" "intr.min 0\n" "ctx.min 0");
 			print_warncrit("intr");
 			print_warncrit("ctx");
 			return 0;
 		}
-		if(!strcmp(argv[1], "autoconf"))
+		if (!strcmp(argv[1], "autoconf"))
 			return autoconf_check_readable(PROC_STAT);
 	}
-	if(!(f=fopen(PROC_STAT, "r")))
+	if (!(f = fopen(PROC_STAT, "r")))
 		return fail("cannot open " PROC_STAT);
-	while(fgets(buff, 256, f)) {
-		if(!strncmp(buff, "intr ", 5)) {
+	while (fgets(buff, 256, f)) {
+		if (!strncmp(buff, "intr ", 5)) {
 			buff[5 + strcspn(buff + 5, " \t\n")] = '\0';
-			printf("intr.value %s\n", buff+5);
-		} else if(!strncmp(buff, "ctxt ", 5)) {
+			printf("intr.value %s\n", buff + 5);
+		} else if (!strncmp(buff, "ctxt ", 5)) {
 			buff[5 + strcspn(buff + 5, " \t\n")] = '\0';
-			printf("ctx.value %s\n", buff+5);
+			printf("ctx.value %s\n", buff + 5);
 		}
 	}
 	fclose(f);

--- a/src/plugins/load.c
+++ b/src/plugins/load.c
@@ -16,28 +16,27 @@
 
 #define PROC_LOADAVG "/proc/loadavg"
 
-int load(int argc, char **argv) {
+int load(int argc, char **argv)
+{
 	FILE *f;
 	float val;
-	if(argc > 1) {
-		if(!strcmp(argv[1], "config")) {
+	if (argc > 1) {
+		if (!strcmp(argv[1], "config")) {
 			puts("graph_title Load average\n"
-				"graph_args --base 1000 -l 0\n"
-				"graph_vlabel load\n"
-				"graph_scale no\n"
-				"graph_category system\n"
-				"load.label load");
+			     "graph_args --base 1000 -l 0\n"
+			     "graph_vlabel load\n"
+			     "graph_scale no\n"
+			     "graph_category system\n" "load.label load");
 			print_warncrit("load");
-			puts("graph_info The load average of the machine describes how many processes are in the run-queue (scheduled to run \"immediately\").\n"
-				"load.info 5 minute load average");
+			puts("graph_info The load average of the machine describes how many processes are in the run-queue (scheduled to run \"immediately\").\n" "load.info 5 minute load average");
 			return 0;
 		}
-		if(!strcmp(argv[1], "autoconf"))
+		if (!strcmp(argv[1], "autoconf"))
 			return writeyes();
 	}
-	if(!(f=fopen(PROC_LOADAVG, "r")))
+	if (!(f = fopen(PROC_LOADAVG, "r")))
 		return fail("cannot open " PROC_LOADAVG);
-	if(1 != fscanf(f, "%*f %f", &val)) {
+	if (1 != fscanf(f, "%*f %f", &val)) {
 		fclose(f);
 		return fail("cannot read from " PROC_LOADAVG);
 	}

--- a/src/plugins/main.c
+++ b/src/plugins/main.c
@@ -13,13 +13,14 @@
 #include "common.h"
 #include "plugins.h"
 
-static int busybox(int argc, char **argv) {
-	if(argc < 2)
+static int busybox(int argc, char **argv)
+{
+	if (argc < 2)
 		return fail("missing parameter");
-	if(0 != strcmp(argv[1], "listplugins"))
+	if (0 != strcmp(argv[1], "listplugins"))
 		return fail("unknown parameter");
-	if(argc > 3 || (argc > 2 &&
-				0 != strcmp(argv[2], "--include-experimental")))
+	if (argc > 3 || (argc > 2 &&
+			 0 != strcmp(argv[2], "--include-experimental")))
 		return fail("unknown option");
 
 	/* The following is focused on readability over efficiency. */
@@ -35,7 +36,7 @@ static int busybox(int argc, char **argv) {
 	puts("threads");
 	puts("uptime");
 
-	if(argc > 2) {
+	if (argc > 2) {
 		puts("memory");
 		puts("processes");
 		puts("external_");
@@ -44,67 +45,69 @@ static int busybox(int argc, char **argv) {
 	return 0;
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	char *progname;
 	char *ext;
 	progname = basename(argv[0]);
 	ext = strrchr(progname, '.');
-	if (ext != NULL) ext[0] = '\0';
-	switch(*progname) {
-		case 'c':
-			if(!strcmp(progname, "cpu"))
-				return cpu(argc, argv);
-			break;
-		case 'e':
-			if(!strcmp(progname, "entropy"))
-				return entropy(argc, argv);
-			if(!strncmp(progname, "external_", strlen("external_")))
-				return external_(argc, argv);
-			break;
-		case 'f':
-			if(!strcmp(progname, "forks"))
-				return forks(argc, argv);
-			if(!strcmp(progname, "fw_packets"))
-				return fw_packets(argc, argv);
-			break;
-		case 'i':
-			if(!strcmp(progname, "interrupts"))
-				return interrupts(argc, argv);
-			if(!strncmp(progname, "if_err_", strlen("if_err_")))
-				return if_err_(argc, argv);
-			break;
-		case 'l':
-			if(!strcmp(progname, "load"))
-				return load(argc, argv);
-			break;
-		case 'm':
-			if(!strcmp(progname, "memory"))
-				return memory(argc, argv);
-			if(!strcmp(progname, "munin-plugins-c"))
-				return busybox(argc, argv);
-			break;
-		case 'o':
-			if(!strcmp(progname, "open_files"))
-				return open_files(argc, argv);
-			if(!strcmp(progname, "open_inodes"))
-				return open_inodes(argc, argv);
-			break;
-		case 'p':
-			if(!strcmp(progname, "processes"))
-				return processes(argc, argv);
-			break;
-		case 's':
-			if(!strcmp(progname, "swap"))
-				return swap(argc, argv);
-			break;
-		case 't':
-			if(!strcmp(progname, "threads"))
-				return threads(argc, argv);
-			break;
-		case 'u':
-			if(!strcmp(progname, "uptime"))
-				return uptime(argc, argv);
-			break;
+	if (ext != NULL)
+		ext[0] = '\0';
+	switch (*progname) {
+	case 'c':
+		if (!strcmp(progname, "cpu"))
+			return cpu(argc, argv);
+		break;
+	case 'e':
+		if (!strcmp(progname, "entropy"))
+			return entropy(argc, argv);
+		if (!strncmp(progname, "external_", strlen("external_")))
+			return external_(argc, argv);
+		break;
+	case 'f':
+		if (!strcmp(progname, "forks"))
+			return forks(argc, argv);
+		if (!strcmp(progname, "fw_packets"))
+			return fw_packets(argc, argv);
+		break;
+	case 'i':
+		if (!strcmp(progname, "interrupts"))
+			return interrupts(argc, argv);
+		if (!strncmp(progname, "if_err_", strlen("if_err_")))
+			return if_err_(argc, argv);
+		break;
+	case 'l':
+		if (!strcmp(progname, "load"))
+			return load(argc, argv);
+		break;
+	case 'm':
+		if (!strcmp(progname, "memory"))
+			return memory(argc, argv);
+		if (!strcmp(progname, "munin-plugins-c"))
+			return busybox(argc, argv);
+		break;
+	case 'o':
+		if (!strcmp(progname, "open_files"))
+			return open_files(argc, argv);
+		if (!strcmp(progname, "open_inodes"))
+			return open_inodes(argc, argv);
+		break;
+	case 'p':
+		if (!strcmp(progname, "processes"))
+			return processes(argc, argv);
+		break;
+	case 's':
+		if (!strcmp(progname, "swap"))
+			return swap(argc, argv);
+		break;
+	case 't':
+		if (!strcmp(progname, "threads"))
+			return threads(argc, argv);
+		break;
+	case 'u':
+		if (!strcmp(progname, "uptime"))
+			return uptime(argc, argv);
+		break;
 	}
 	return fail("unknown basename");
 }

--- a/src/plugins/memory.c
+++ b/src/plugins/memory.c
@@ -80,31 +80,32 @@ SwapFree:     215608 kB
 */
 
 /* TODO - For now we only support Cygwin fields. */
-int memory(int argc, char **argv) {
+int memory(int argc, char **argv)
+{
 	FILE *f;
 	char buff[256];
 
 	int_fast64_t mem_total = -1;
-	int_fast64_t mem_free  = -1;
+	int_fast64_t mem_free = -1;
 	int_fast64_t swap_total = -1;
-	int_fast64_t swap_free  = -1;
+	int_fast64_t swap_free = -1;
 
-	if(argc > 1) {
-		if(!strcmp(argv[1], "config")) {
-			printf(
-				"graph_args --base 1024 -l 0\n"
-				"graph_vlabel Bytes\n"
-				"graph_title Memory usage\n"
-				"graph_category system\n"
-				"graph_info This graph shows what the machine uses memory for.\n"
-			);
+	if (argc > 1) {
+		if (!strcmp(argv[1], "config")) {
+			printf("graph_args --base 1024 -l 0\n"
+			       "graph_vlabel Bytes\n"
+			       "graph_title Memory usage\n"
+			       "graph_category system\n"
+			       "graph_info This graph shows what the machine uses memory for.\n");
 			printf("apps.label apps\n");
 			printf("apps.draw AREA\n");
-			printf("apps.info Memory used by user-space applications.\n");
+			printf
+			    ("apps.info Memory used by user-space applications.\n");
 
 			printf("free.label free\n");
 			printf("free.draw STACK\n");
-			printf("free.info Wasted memory. Memory that is not used for anything at all.\n");
+			printf
+			    ("free.info Wasted memory. Memory that is not used for anything at all.\n");
 
 			printf("swap.label swap\n");
 			printf("swap.draw STACK\n");
@@ -112,15 +113,15 @@ int memory(int argc, char **argv) {
 
 			return 0;
 		}
-		if(!strcmp(argv[1], "autoconf"))
+		if (!strcmp(argv[1], "autoconf"))
 			return autoconf_check_readable(PROC_MEMINFO);
 	}
 
 	/* Asking for a fetch */
-	if(!(f=fopen(PROC_MEMINFO, "r")))
+	if (!(f = fopen(PROC_MEMINFO, "r")))
 		return fail("cannot open " PROC_MEMINFO);
 
-	while(fgets(buff, 256, f)) {
+	while (fgets(buff, 256, f)) {
 		char key[256];
 		int_fast64_t value;
 		if (!sscanf(buff, "%s %" SCNdFAST64, key, &value)) {
@@ -128,17 +129,18 @@ int memory(int argc, char **argv) {
 			return fail("cannot parse " PROC_MEMINFO " line");
 		}
 
-		if(!strcmp(key, "MemTotal:"))
+		if (!strcmp(key, "MemTotal:"))
 			mem_total = value * 1024;
-		else if(!strcmp(key, "MemFree:"))
+		else if (!strcmp(key, "MemFree:"))
 			mem_free = value * 1024;
-		else if(!strcmp(key, "SwapTotal:"))
+		else if (!strcmp(key, "SwapTotal:"))
 			swap_total = value * 1024;
-		else if(!strcmp(key, "SwapFree:"))
+		else if (!strcmp(key, "SwapFree:"))
 			swap_free = value * 1024;
 	}
 	fclose(f);
-	if(mem_total < 0 || mem_free < 0 || swap_total < 0 || swap_free < 0)
+	if (mem_total < 0 || mem_free < 0 || swap_total < 0
+	    || swap_free < 0)
 		return fail("missing fileds in " PROC_MEMINFO);
 
 	printf("apps.value %" PRIdFAST64 "\n", mem_total - mem_free);

--- a/src/plugins/open_files.c
+++ b/src/plugins/open_files.c
@@ -15,43 +15,44 @@
 
 /* TODO: support env.warning and friends after the upstream plugin is fixed */
 
-int open_files(int argc, char **argv) {
+int open_files(int argc, char **argv)
+{
 	FILE *f;
 	int alloc, freeh, avail;
-	if(argc > 1) {
-		if(!strcmp(argv[1], "config")) {
-			if(!(f=fopen(FS_FILE_NR, "r")))
+	if (argc > 1) {
+		if (!strcmp(argv[1], "config")) {
+			if (!(f = fopen(FS_FILE_NR, "r")))
 				return fail("cannot open " FS_FILE_NR);
-			if(1 != fscanf(f, "%*d %*d %d", &avail)) {
+			if (1 != fscanf(f, "%*d %*d %d", &avail)) {
 				fclose(f);
-				return fail("cannot read from " FS_FILE_NR);
+				return fail("cannot read from "
+					    FS_FILE_NR);
 			}
 			fclose(f);
 			puts("graph_title File table usage\n"
-				"graph_args --base 1000 -l 0\n"
-				"graph_vlabel number of open files\n"
-				"graph_category system\n"
-				"graph_info This graph monitors the Linux open files table.\n"
-				"used.label open files\n"
-				"used.info The number of currently open files.\n"
-				"max.label max open files\n"
-				"max.info The maximum supported number of open "
-					"files. Tune by modifying " FS_FILE_NR
-					".");
+			     "graph_args --base 1000 -l 0\n"
+			     "graph_vlabel number of open files\n"
+			     "graph_category system\n"
+			     "graph_info This graph monitors the Linux open files table.\n"
+			     "used.label open files\n"
+			     "used.info The number of currently open files.\n"
+			     "max.label max open files\n"
+			     "max.info The maximum supported number of open "
+			     "files. Tune by modifying " FS_FILE_NR ".");
 			printf("used.warning %d\nused.critical %d\n",
-					(int)(avail*0.92), (int)(avail*0.98));
+			       (int) (avail * 0.92), (int) (avail * 0.98));
 			return 0;
 		}
-		if(!strcmp(argv[1], "autoconf"))
+		if (!strcmp(argv[1], "autoconf"))
 			return autoconf_check_readable(FS_FILE_NR);
 	}
-	if(!(f=fopen(FS_FILE_NR, "r")))
+	if (!(f = fopen(FS_FILE_NR, "r")))
 		return fail("cannot open " FS_FILE_NR);
-	if(3 != fscanf(f, "%d %d %d", &alloc, &freeh, &avail)) {
+	if (3 != fscanf(f, "%d %d %d", &alloc, &freeh, &avail)) {
 		fclose(f);
 		return fail("cannot read from " FS_FILE_NR);
 	}
 	fclose(f);
-	printf("used.value %d\nmax.value %d\n", alloc-freeh, avail);
+	printf("used.value %d\nmax.value %d\n", alloc - freeh, avail);
 	return 0;
 }

--- a/src/plugins/open_inodes.c
+++ b/src/plugins/open_inodes.c
@@ -16,34 +16,35 @@
 
 #define FS_INODE_NR "/proc/sys/fs/inode-nr"
 
-int open_inodes(int argc, char **argv) {
+int open_inodes(int argc, char **argv)
+{
 	FILE *f;
 	int nr, freen;
-	if(argc > 1) {
-		if(!strcmp(argv[1], "config")) {
+	if (argc > 1) {
+		if (!strcmp(argv[1], "config")) {
 			puts("graph_title Inode table usage\n"
-				"graph_args --base 1000 -l 0\n"
-				"graph_vlabel number of open inodes\n"
-				"graph_category system\n"
-				"graph_info This graph monitors the Linux open inode table.\n"
-				"used.label open inodes\n"
-				"used.info The number of currently open inodes.\n"
-				"max.label inode table size\n"
-				"max.info The size of the system inode table. This is dynamically adjusted by the kernel.");
+			     "graph_args --base 1000 -l 0\n"
+			     "graph_vlabel number of open inodes\n"
+			     "graph_category system\n"
+			     "graph_info This graph monitors the Linux open inode table.\n"
+			     "used.label open inodes\n"
+			     "used.info The number of currently open inodes.\n"
+			     "max.label inode table size\n"
+			     "max.info The size of the system inode table. This is dynamically adjusted by the kernel.");
 			print_warncrit("used");
 			print_warncrit("max");
 			return 0;
 		}
-		if(!strcmp(argv[1], "autoconf"))
+		if (!strcmp(argv[1], "autoconf"))
 			return autoconf_check_readable(FS_INODE_NR);
 	}
-	if(!(f=fopen(FS_INODE_NR, "r")))
+	if (!(f = fopen(FS_INODE_NR, "r")))
 		return fail("cannot open " FS_INODE_NR);
-	if(2 != fscanf(f, "%d %d", &nr, &freen)) {
+	if (2 != fscanf(f, "%d %d", &nr, &freen)) {
 		fclose(f);
 		return fail("cannot read from " FS_INODE_NR);
 	}
 	fclose(f);
-	printf("used.value %d\nmax.value %d\n", nr-freen, nr);
+	printf("used.value %d\nmax.value %d\n", nr - freen, nr);
 	return 0;
 }

--- a/src/plugins/processes.c
+++ b/src/plugins/processes.c
@@ -18,45 +18,47 @@
 
 /* TODO: The upstream plugin does way more nowawdays. */
 
-int processes(int argc, char **argv) {
+int processes(int argc, char **argv)
+{
 	DIR *d;
 	struct dirent *e;
 	char *s;
-	int n=0;
+	int n = 0;
 	struct stat statbuf;
 
-	if(argc > 1) {
-		if(!strcmp(argv[1], "config")) {
+	if (argc > 1) {
+		if (!strcmp(argv[1], "config")) {
 			puts("graph_title Number of Processes\n"
-				"graph_args --base 1000 -l 0 \n"
-				"graph_vlabel number of processes\n"
-				"graph_category processes\n"
-				"graph_info This graph shows the number of processes in the system.\n"
-				"processes.label processes\n"
-				"processes.draw LINE2\n"
-				"processes.info The current number of processes.");
+			     "graph_args --base 1000 -l 0 \n"
+			     "graph_vlabel number of processes\n"
+			     "graph_category processes\n"
+			     "graph_info This graph shows the number of processes in the system.\n"
+			     "processes.label processes\n"
+			     "processes.draw LINE2\n"
+			     "processes.info The current number of processes.");
 			return 0;
 		}
-		if(!strcmp(argv[1], "autoconf")) {
-			if(0 != stat("/proc/1", &statbuf)) {
-				printf("no (cannot stat /proc/1, errno=%d)\n",
-						errno);
+		if (!strcmp(argv[1], "autoconf")) {
+			if (0 != stat("/proc/1", &statbuf)) {
+				printf
+				    ("no (cannot stat /proc/1, errno=%d)\n",
+				     errno);
 				return 1;
 			}
-			if(!S_ISDIR(statbuf.st_mode)) {
+			if (!S_ISDIR(statbuf.st_mode)) {
 				printf("no (/proc/1 is not a directory\n");
 				return 1;
 			}
 			return writeyes();
 		}
 	}
-	if(!(d = opendir("/proc")))
+	if (!(d = opendir("/proc")))
 		return fail("cannot open /proc");
-	while((e = readdir(d))) {
-		for(s=e->d_name;*s;++s)
-			if(!xisdigit(*s))
+	while ((e = readdir(d))) {
+		for (s = e->d_name; *s; ++s)
+			if (!xisdigit(*s))
 				break;
-		if(!*s)
+		if (!*s)
 			++n;
 	}
 	closedir(d);

--- a/src/plugins/swap.c
+++ b/src/plugins/swap.c
@@ -17,59 +17,64 @@
 
 #define PROC_VMSTAT "/proc/vmstat"
 
-int swap(int argc, char **argv) {
+int swap(int argc, char **argv)
+{
 	FILE *f;
 	char buff[256];
 	bool in, out;
 	int inval, outval;
-	if(argc > 1) {
-		if(!strcmp(argv[1], "config")) {
+	if (argc > 1) {
+		if (!strcmp(argv[1], "config")) {
 			puts("graph_title Swap in/out\n"
-				"graph_args -l 0 --base 1000\n"
-				"graph_vlabel pages per ${graph_period} in (-) / out (+)\n"
-				"graph_category system\n"
-				"swap_in.label swap\n"
-				"swap_in.type DERIVE\n"
-				"swap_in.max 100000\n"
-				"swap_in.min 0\n"
-				"swap_in.graph no\n"
-				"swap_out.label swap\n"
-				"swap_out.type DERIVE\n"
-				"swap_out.max 100000\n"
-				"swap_out.min 0\n"
-				"swap_out.negative swap_in");
+			     "graph_args -l 0 --base 1000\n"
+			     "graph_vlabel pages per ${graph_period} in (-) / out (+)\n"
+			     "graph_category system\n"
+			     "swap_in.label swap\n"
+			     "swap_in.type DERIVE\n"
+			     "swap_in.max 100000\n"
+			     "swap_in.min 0\n"
+			     "swap_in.graph no\n"
+			     "swap_out.label swap\n"
+			     "swap_out.type DERIVE\n"
+			     "swap_out.max 100000\n"
+			     "swap_out.min 0\n"
+			     "swap_out.negative swap_in");
 			print_warncrit("swap_in");
 			print_warncrit("swap_out");
 			return 0;
 		}
-		if(!strcmp(argv[1], "autoconf"))
+		if (!strcmp(argv[1], "autoconf"))
 			return autoconf_check_readable(PROC_STAT);
 	}
-	if((f=fopen(PROC_VMSTAT, "r"))) {
+	if ((f = fopen(PROC_VMSTAT, "r"))) {
 		in = out = false;
-		while(fgets(buff, 256, f)) {
-			if(!in && !strncmp(buff, "pswpin ", 7)) {
+		while (fgets(buff, 256, f)) {
+			if (!in && !strncmp(buff, "pswpin ", 7)) {
 				in = true;
-				printf("swap_in.value %s", buff+7);
-			}
-			else if(!out && !strncmp(buff, "pswpout ", 8)) {
+				printf("swap_in.value %s", buff + 7);
+			} else if (!out && !strncmp(buff, "pswpout ", 8)) {
 				out = true;
-				printf("swap_out.value %s", buff+8);
+				printf("swap_out.value %s", buff + 8);
 			}
 		}
 		fclose(f);
-		if(!(in && out))
+		if (!(in && out))
 			return fail("no usable data on " PROC_VMSTAT);
 		return 0;
 	} else {
-		if(!(f=fopen(PROC_STAT, "r")))
+		if (!(f = fopen(PROC_STAT, "r")))
 			return fail("cannot open " PROC_STAT);
-		while(fgets(buff, 256, f)) {
-			if(!strncmp(buff, "swap ", 5)) {
+		while (fgets(buff, 256, f)) {
+			if (!strncmp(buff, "swap ", 5)) {
 				fclose(f);
-				if(2 != sscanf(buff+5, "%d %d", &inval, &outval))
-					return fail("bad data on " PROC_STAT);
-				printf("swap_in.value %d\nswap_out.value %d\n", inval, outval);
+				if (2 !=
+				    sscanf(buff + 5, "%d %d", &inval,
+					   &outval))
+					return fail("bad data on "
+						    PROC_STAT);
+				printf
+				    ("swap_in.value %d\nswap_out.value %d\n",
+				     inval, outval);
 				return 0;
 			}
 		}

--- a/src/plugins/threads.c
+++ b/src/plugins/threads.c
@@ -17,7 +17,8 @@
 #include "common.h"
 #include "plugins.h"
 
-int threads(int argc, char **argv) {
+int threads(int argc, char **argv)
+{
 	FILE *f;
 	char buff[270];
 	const char *s;
@@ -25,14 +26,15 @@ int threads(int argc, char **argv) {
 	DIR *d;
 	struct dirent *e;
 
-	if(argc > 1) {
-		if(!strcmp(argv[1], "autoconf")) {
+	if (argc > 1) {
+		if (!strcmp(argv[1], "autoconf")) {
 			i = getpid();
 			snprintf(buff, sizeof(buff), "/proc/%d/status", i);
-			if(NULL == (f = fopen(buff, "r")))
-				return fail("failed to open /proc/$$/status");
-			while(fgets(buff, 256, f))
-				if(!strncmp(buff, "Threads:", 8)) {
+			if (NULL == (f = fopen(buff, "r")))
+				return
+				    fail("failed to open /proc/$$/status");
+			while (fgets(buff, 256, f))
+				if (!strncmp(buff, "Threads:", 8)) {
 					fclose(f);
 					return writeyes();
 				}
@@ -40,36 +42,36 @@ int threads(int argc, char **argv) {
 			puts("no");
 			return 0;
 		}
-		if(!strcmp(argv[1], "config")) {
+		if (!strcmp(argv[1], "config")) {
 			puts("graph_title Number of threads\n"
-				"graph_vlabel number of threads\n"
-				"graph_category processes\n"
-				"graph_info This graph shows the number of threads.\n"
-				"threads.label threads\n"
-				"threads.info The current number of threads.");
+			     "graph_vlabel number of threads\n"
+			     "graph_category processes\n"
+			     "graph_info This graph shows the number of threads.\n"
+			     "threads.label threads\n"
+			     "threads.info The current number of threads.");
 			return 0;
 		}
 	}
-	if(NULL == (d = opendir("/proc")))
+	if (NULL == (d = opendir("/proc")))
 		return fail("cannot open /proc");
 	sum = 0;
-	while((e = readdir(d))) {
-		for(s=e->d_name;*s;++s)
-			if(!xisdigit(*s))
+	while ((e = readdir(d))) {
+		for (s = e->d_name; *s; ++s)
+			if (!xisdigit(*s))
 				break;
-		if(*s) /* non-digit found */
+		if (*s)		/* non-digit found */
 			continue;
 		snprintf(buff, 270, "/proc/%s/status", e->d_name);
-		if(!(f = fopen(buff, "r")))
-			continue; /* process has vanished */
-		while(fgets(buff, 256, f)) {
-			if(strncmp(buff, "Threads:", 8))
+		if (!(f = fopen(buff, "r")))
+			continue;	/* process has vanished */
+		while (fgets(buff, 256, f)) {
+			if (strncmp(buff, "Threads:", 8))
 				continue;
-			if(1 != sscanf(buff+8, "%d", &i)) {
+			if (1 != sscanf(buff + 8, "%d", &i)) {
 				fclose(f);
 				closedir(d);
 				return fail("failed to parse "
-						"/proc/somepid/status");
+					    "/proc/somepid/status");
 			}
 			sum += i;
 		}

--- a/src/plugins/uptime.c
+++ b/src/plugins/uptime.c
@@ -15,30 +15,30 @@
 
 #define PROC_UPTIME "/proc/uptime"
 
-int uptime(int argc, char **argv) {
+int uptime(int argc, char **argv)
+{
 	FILE *f;
 	float uptime;
-	if(argc > 1) {
-		if(!strcmp(argv[1], "config")) {
+	if (argc > 1) {
+		if (!strcmp(argv[1], "config")) {
 			puts("graph_title Uptime\n"
-				"graph_args --base 1000 -l 0 \n"
-				"graph_vlabel uptime in days\n"
-				"graph_category system\n"
-				"uptime.label uptime\n"
-				"uptime.draw AREA");
+			     "graph_args --base 1000 -l 0 \n"
+			     "graph_vlabel uptime in days\n"
+			     "graph_category system\n"
+			     "uptime.label uptime\n" "uptime.draw AREA");
 			print_warncrit("uptime");
 			return 0;
 		}
-		if(!strcmp(argv[1], "autoconf"))
+		if (!strcmp(argv[1], "autoconf"))
 			return writeyes();
 	}
-	if(!(f=fopen(PROC_UPTIME, "r")))
+	if (!(f = fopen(PROC_UPTIME, "r")))
 		return fail("cannot open " PROC_UPTIME);
-	if(1 != fscanf(f, "%f", &uptime)) {
+	if (1 != fscanf(f, "%f", &uptime)) {
 		fclose(f);
 		return fail("cannot read from " PROC_UPTIME);
 	}
 	fclose(f);
-	printf("uptime.value %.2f\n", uptime/86400);
+	printf("uptime.value %.2f\n", uptime / 86400);
 	return 0;
 }

--- a/t/common.c
+++ b/t/common.c
@@ -3,7 +3,8 @@
 
 #include "common.h"
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[])
+{
 	int is_config = (argc == 2) && (strcmp(argv[1], "config") == 0);
 	return is_config ? emit_config() : emit_fetch();
 }

--- a/t/nb_env.c
+++ b/t/nb_env.c
@@ -5,25 +5,28 @@
 
 extern char **environ;
 
-int count_env_nb() {
+int count_env_nb()
+{
 	int env_nb = 0;
 	char **cur_environ = environ;
 	while (*cur_environ) {
-		env_nb ++;
-		cur_environ ++;
+		env_nb++;
+		cur_environ++;
 	}
 
 	return env_nb;
 }
 
-int emit_config() {
+int emit_config()
+{
 	printf("graph_title " __FILE__ "\n");
 	printf("env_nb.label Number of env vars\n");
 
 	return 0;
 }
 
-int emit_fetch() {
+int emit_fetch()
+{
 	char **cur_environ = environ;
 
 	printf("env_nb.value %d\n", count_env_nb());
@@ -31,7 +34,7 @@ int emit_fetch() {
 
 	while (*cur_environ) {
 		printf("{%s},", *cur_environ);
-		cur_environ ++;
+		cur_environ++;
 	}
 
 	printf("\n");

--- a/t/ok_plugin.c
+++ b/t/ok_plugin.c
@@ -2,7 +2,8 @@
 
 #include "common.h"
 
-int emit_config() {
+int emit_config()
+{
 	printf("graph_title " __FILE__ "\n");
 	printf("first_f.label This is the first field\n");
 	printf("second_f.label This is the second field\n");
@@ -10,7 +11,8 @@ int emit_config() {
 	return 0;
 }
 
-int emit_fetch() {
+int emit_fetch()
+{
 	printf("first_f.value %f\n", 1234.567);
 	printf("second_f.value %f\n", -2345.678);
 


### PR DESCRIPTION
While reviewing a pull request i noticed a different indention style and
tried to fix that in an automated way. But i wasn't able to describe the
rules for the actual coding style. So i looked up what the kernel devs
do and found a useable indent command line here:

https://www.kernel.org/doc/html/v4.20/process/coding-style.html

If we agree in using the kernel coding style the following indent
commandline can be use to format the source accordingly:

  indent -kr -i8

Signed-off-by: Matthias Schmitz <matthias@sigxcpu.org>