### PR TITLE
Make getenv_composed() static as it is only used in common.c

### DIFF
--- a/src/plugins/common.c
+++ b/src/plugins/common.c
@@ -36,7 +36,7 @@ int getenvint(const char *name, int defvalue) {
 	return atoi(value);
 }
 
-/*@null@*/ /*@observer@*/ const char *getenv_composed(const char *name1,
+static /*@null@*/ /*@observer@*/ const char *getenv_composed(const char *name1,
 		const char *name2) {
 	char **p;
 	size_t len1 = strlen(name1), len2 = strlen(name2);

--- a/src/plugins/common.h
+++ b/src/plugins/common.h
@@ -23,11 +23,6 @@ int autoconf_check_readable(const char *);
  * variable the given defaultvalue is returned.  */
 int getenvint(const char *, int defaultvalue);
 
-/** Return the value of the environment variable referred to by the
- * concatenation of the given strings.  */
-/*@null@*/ /*@observer@*/ const char *getenv_composed(const char *,
-		const char *);
-
 /** Print a name.warning line using the "name_warning" or "warning" environment
  * variables. */
 void print_warning(const char *name);


### PR DESCRIPTION
indent get confused if the line starts with a splint annotion. Making
the function static works around that as the function is used in
common.c only anyway and so the line didn't start with a annotation.