### PR TITLE
 Run travis build with gcc-8 and dpkg-buildflags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ matrix:
     - os: osx
       compiler: clang
     - os: linux
+      compiler: gcc-8
+      env:
+        - LDFLAGS="-Wl,-z,relro"
+        - CFLAGS="-g -O2 -fstack-protector-strong -Wformat -Werror=format-security"
+        - CPPFLAGS="-Wdate-time -D_FORTIFY_SOURCE=2"
+    - os: linux
       compiler: gcc
       env:
         - LDFLAGS=
@@ -53,9 +59,12 @@ env:
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
       - musl-tools
       - indent
+      - gcc-8
   homebrew:
     packages:
       - gnu-indent

--- a/src/plugins/df.c
+++ b/src/plugins/df.c
@@ -73,7 +73,7 @@ int df(int argc, char **argv)
 		if (strcmp(argv[1], "config") == 0) {
 			printf("graph_title Disk usage in percent\n"
 			       "graph_args --upper-limit 100 -l 0\n"
-			       "graph_vlabel %\n"
+			       "graph_vlabel %%\n"
 			       "graph_scale no\n" "graph_category disk\n");
 
 			while ((fs = getmntent(fp)) != NULL) {


### PR DESCRIPTION
Referring to https://wiki.debian.org/Hardening :
"Several compile-time options (...) can be used to help harden a
resulting binary against memory corruption attacks.."

Debian uses a lot of hardening flags to build the packages. To catch
issues early run a build with this flags using gcc-8 in travis as well.