### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,51 @@ matrix:
       compiler: musl-gcc
       env:
         - LDFLAGS=-static
+# Adding ppc64le jobs
+    - os: linux
+      arch: ppc64le
+      dist: bionic
+      compiler: gcc-8
+      env:
+        - LDFLAGS="-Wl,-z,relro"
+        - CFLAGS="-g -O2 -fstack-protector-strong -Wformat -Werror=format-security"
+        - CPPFLAGS="-Wdate-time -D_FORTIFY_SOURCE=2"
+    - os: linux
+      arch: ppc64le
+      dist: bionic
+      compiler: gcc
+      env:
+        - LDFLAGS=
+    - os: linux
+      arch: ppc64le
+      dist: bionic
+      compiler: gcc
+      env:
+        - LDFLAGS=-static
+    - os: linux
+      arch: ppc64le
+      dist: bionic
+      compiler: clang
+      env:
+        - LDFLAGS=
+    - os: linux
+      arch: ppc64le
+      dist: bionic
+      compiler: clang
+      env:
+        - LDFLAGS=-static
+    - os: linux
+      arch: ppc64le
+      dist: bionic
+      compiler: musl-gcc
+      env:
+        - LDFLAGS=
+    - os: linux
+      arch: ppc64le
+      dist: bionic
+      compiler: musl-gcc
+      env:
+        - LDFLAGS=-static
 
 language: c
 


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR and looks like its been successfully added. As musl-tools package is not available on Xenial, hence running on Bionic flavor for ppc64le. I believe it is ready for the final review and merge. The Travis-CI build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/munin-c/builds/205846322

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj