### PR TITLE
Reverting on the usage of posix_spawn() instead of fork/exec

### DIFF
--- a/src/node/inetd.c
+++ b/src/node/inetd.c
@@ -82,8 +82,8 @@ int main(int argc, char *argv[])
 	/* We do *not* care about childs */
 	signal(SIGCHLD, SIG_IGN);
 
-	while((sock_accept = accept(sock_listen, NULL, NULL)) != -1) {
-		if(0 == (pid = vfork())) {
+	while ((sock_accept = accept(sock_listen, NULL, NULL)) != -1) {
+		if (0 == (pid = vfork())) {
 			close(sock_listen);
 			dup2(sock_accept, 0);
 			dup2(sock_accept, 1);

--- a/src/node/node.c
+++ b/src/node/node.c
@@ -26,7 +26,6 @@
 #include <grp.h>
 #include <fnmatch.h>
 #include <ctype.h>
-#include <spawn.h>
 
 #ifndef HOST_NAME_MAX
 #define HOST_NAME_MAX 256
@@ -649,7 +648,7 @@ static int handle_connection()
 				continue;
 			}
 
-			/* Using posix_spawnp() here instead of fork() since we will
+			/* Using fork() here instead of vork() since we will
 			 * do a little more than a mere exec --> setenvvars_conf() */
 			pid = fork();
 


### PR DESCRIPTION
Embedded versions of the libc (uClibc) don't always have `posix_spawn()` and other fancy functions. Besides, the code is much simpler without it. 

We might need to find a suitable replacement when porting to OS without `fork()` such as win32. But there, the `munin-node-win32` might be a better replacement anyway. I never managed to have a satisfactory portable execution of `munin-c` there anyway.
