### PR TITLE
Adding legacy "fetch"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,5 +25,15 @@ CC_CHECK_CFLAGS_APPEND([-Wall -Wextra -Werror -pedantic -Wno-format])
 
 AC_CHECK_HEADERS([mntent.h sys/vfs.h])
 
+AC_MSG_CHECKING([whether to enable legacy "fetch"])
+AC_ARG_WITH(legacy_fetch,
+	    [  --with-legacy-fetch     enable legacy fetch which does not add "fetch") @<:@yes@:>@],
+    with_legacy_fetch=$withval,
+    with_legacy_fetch=yes)
+AC_MSG_RESULT($with_legacy_fetch)
+if test "$with_legacy_fetch" = "yes"; then
+  AC_DEFINE(LEGACY_FETCH)
+fi
+
 AC_CONFIG_FILES([Makefile src/node/Makefile src/plugins/Makefile t/Makefile])
 AC_OUTPUT

--- a/src/node/node.c
+++ b/src/node/node.c
@@ -658,6 +658,12 @@ static int handle_connection()
 			} else if (pid == 0) {
 				/* Now is the time to set environnement */
 				setenvvars_conf(arg);
+#ifdef LEGACY_FETCH
+				/* The munin-node implementation does not set arg[1] if "fetch" */
+				if (strcmp(cmd, "fetch") == 0) {
+					cmd = NULL;
+				}
+#endif // LEGACY_FETCH
 				execl(cmdline, arg, cmd, NULL);
 			}
 


### PR DESCRIPTION
In munin-node, when asking for fetch, it launchs the plugin without any
args.

We activate it by default, as munin-node is the defacto standard.