### PR TITLE
fix fatal typo in print_critical

### DIFF
--- a/src/plugins/common.c
+++ b/src/plugins/common.c
@@ -68,7 +68,7 @@ void print_critical(const char *name) {
 	if(p == NULL)
 		return;
 
-	printf("%s.critial %s\n", name, p);
+	printf("%s.critical %s\n", name, p);
 }
 
 void print_warncrit(const char *name) {


### PR DESCRIPTION
Reported-By: Gerald Turner <gturner@unzane.com>
Debian-Bug: #783431