### PR TITLE
node: allocate for plugin-conf env vars as needed

### DIFF
--- a/src/node/node.c
+++ b/src/node/node.c
@@ -338,6 +338,12 @@ static void set_value(struct s_plugin_conf *conf, const char *key,
 	struct s_env *env = NULL;
 	struct s_env **nextp = &conf->env_head;
 
+	if (key_len + strlen(value) + 1 >= MAX_ENV_BUF_SZ) {
+		fprintf(stderr, "env var key+value too long: %.30s...\n",
+			key);
+		abort();
+	}
+
 	/* Search for the corresponding env */
 	for (; *nextp != NULL; nextp = &(*nextp)->next) {
 		env = *nextp;


### PR DESCRIPTION
Avoid allocating space for 256 env vars in the conf struct on the stack, when typically just a couple env vars are set.

Technically, using memory in a stack frame that exits for putenv() was an error, because putenv() uses a reference to the passed argument (unlike setenv() which copies them).

-----------------

Not really a big deal, 70K on the stack in userspace is totally fine, even for embedded, I think. Just kinda bothered by this big block mostly unused. And then I ran into the `putenv()` referencing thing. Could switch to `setenv()`, just need to split key/value, which can be done in place by just poking a null byte after keylen ...