### PR TITLE
minor CI update: checkout@v3, show indent diff

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -15,22 +15,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: install indent
       run: sudo apt-get -y install indent
-    - name: enforce code style - C files
-      run: find . -iname "*.c" -exec indent -kr -i8 {} \;
-    - name: enforce code style - H files
-      run: find . -iname "*.h" -exec indent -kr -i8 {} \;
+
+    - name: enforce code style
+      run: find . -iname "*.[ch]" -exec indent -kr -i8 {} \;
+
     - name: check code style
-      run: git diff --quiet
+      run: git diff --exit-code
+
     - name: autoconf
       run: autoreconf -i -I m4
+
     - name: configure
       run: ./configure
+
     - name: make
       run: make
+
     - name: make check
       run: make check
+
     - name: make distcheck
       run: make distcheck


### PR DESCRIPTION
 * update to actions/checkout@v3 to fix deprecated output warning
 * combine .c/.h indent step
 * show indent diff (git diff --quiet implies --exit-code, really just need --exit-code)
 * add blank lines between steps for readability


I'm happy to drop bits of this if they are not desired :)